### PR TITLE
Align Libtorch Gibbs energy surrogate with tensor options

### DIFF
--- a/src/tensor_computes/LibtorchGibbsEnergy.C
+++ b/src/tensor_computes/LibtorchGibbsEnergy.C
@@ -7,6 +7,7 @@
 /**********************************************************************/
 
 #include "LibtorchGibbsEnergy.h"
+#include "SwiftUtils.h"
 #include <valarray>
 #include <vector>
 
@@ -37,8 +38,9 @@ LibtorchGibbsEnergy::LibtorchGibbsEnergy(const InputParameters & parameters)
     _file_path(Moose::DataFileUtils::getPath(getParam<DataFileName>("libtorch_model_file"))),
     _surrogate(std::make_unique<torch::jit::script::Module>(torch::jit::load(_file_path.path)))
 {
-
-//   _surrogate->to(_device_names[0]);
+  const auto options = MooseTensor::floatTensorOptions();
+  _surrogate->to(options.device());
+  _surrogate->to(*options.dtype());
 
   auto phase_fractions = getParam<std::vector<TensorInputBufferName>>("phase_fractions");
   auto domega_detas = getParam<std::vector<TensorOutputBufferName>>("domega_detas");


### PR DESCRIPTION
## Summary
- include SwiftUtils so the Gibbs energy surrogate can query MooseTensor tensor options
- move the loaded libtorch module to the domain-configured device and precision

## Testing
- make -j2 *(fails: `/workspace/moose/framework/app.mk: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_68cb6148c7888321a9073c2f9334fbd7