### PR TITLE
Set Libtorch Gibbs energy surrogate to evaluation mode

### DIFF
--- a/src/tensor_computes/LibtorchGibbsEnergy.C
+++ b/src/tensor_computes/LibtorchGibbsEnergy.C
@@ -7,6 +7,7 @@
 /**********************************************************************/
 
 #include "LibtorchGibbsEnergy.h"
+#include "SwiftUtils.h"
 #include <valarray>
 #include <vector>
 
@@ -37,8 +38,9 @@ LibtorchGibbsEnergy::LibtorchGibbsEnergy(const InputParameters & parameters)
     _file_path(Moose::DataFileUtils::getPath(getParam<DataFileName>("libtorch_model_file"))),
     _surrogate(std::make_unique<torch::jit::script::Module>(torch::jit::load(_file_path.path)))
 {
-
-//   _surrogate->to(_device_names[0]);
+  const auto options = MooseTensor::floatTensorOptions();
+  _surrogate->to(options);
+  _surrogate->eval();
 
   auto phase_fractions = getParam<std::vector<TensorInputBufferName>>("phase_fractions");
   auto domega_detas = getParam<std::vector<TensorOutputBufferName>>("domega_detas");


### PR DESCRIPTION
## Summary
- move the Gibbs energy libtorch module to the runtime tensor options upon construction
- switch the surrogate to inference-only mode by calling eval() immediately after the transfer

## Testing
- not run (TestHarness Python module is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68cb615712fc8321a6d4e7d3b0884cd8