### PR TITLE
Use default retain_graph in Libtorch gradients

### DIFF
--- a/src/tensor_computes/LibtorchGibbsEnergy.C
+++ b/src/tensor_computes/LibtorchGibbsEnergy.C
@@ -90,7 +90,7 @@ LibtorchGibbsEnergy::computeBuffer()
   std::vector<torch::Tensor> grads = torch::autograd::grad({G},
                                                            {X_flat},
                                                            /*grad_outputs=*/{grad_output},
-                                                           /*retain_graph=*/true,
+                                                           /*retain_graph=*/false,
                                                            /*create_graph=*/false,
                                                            /*allow_unused=*/false);
   auto jacobian_flat = grads[0];


### PR DESCRIPTION
## Summary
- avoid retaining the autograd graph when requesting gradients in LibtorchGibbsEnergy since the results are consumed immediately

## Testing
- make -j2 *(fails: missing moose submodule providing framework/app.mk)*
- ./run_tests -h *(fails: missing moose TestHarness module)*

------
https://chatgpt.com/codex/tasks/task_e_68cb649b038c83218ccbcf662cafa6c5