### PR TITLE
Use scalar reduction for Libtorch Gibbs energy gradients

### DIFF
--- a/src/tensor_computes/LibtorchGibbsEnergy.C
+++ b/src/tensor_computes/LibtorchGibbsEnergy.C
@@ -86,10 +86,9 @@ LibtorchGibbsEnergy::computeBuffer()
 
   auto G = _surrogate->forward({X_flat}).toTensor().squeeze();
 
-  auto grad_output = torch::ones_like(G);
-  std::vector<torch::Tensor> grads = torch::autograd::grad({G},
+  std::vector<torch::Tensor> grads = torch::autograd::grad({G.sum()},
                                                            {X_flat},
-                                                           /*grad_outputs=*/{grad_output},
+                                                           /*grad_outputs=*/{},
                                                            /*retain_graph=*/true,
                                                            /*create_graph=*/false,
                                                            /*allow_unused=*/false);


### PR DESCRIPTION
## Summary
- compute autograd gradients for the Gibbs energy by reducing the output to a scalar
- avoid creating a temporary all-ones tensor while keeping the downstream buffer logic unchanged

## Testing
- ./run_tests --re KKS_libtorch *(fails: ModuleNotFoundError: No module named 'TestHarness')*


------
https://chatgpt.com/codex/tasks/task_e_68cb64a01878832196c511658a943177